### PR TITLE
Increase kMaxIterations to fix #1663

### DIFF
--- a/src/benchmark_runner.cc
+++ b/src/benchmark_runner.cc
@@ -64,7 +64,7 @@ MemoryManager* memory_manager = nullptr;
 
 namespace {
 
-static constexpr IterationCount kMaxIterations = 1000000000;
+static constexpr IterationCount kMaxIterations = 1000000000000;
 const double kDefaultMinTime =
     std::strtod(::benchmark::kDefaultMinTimeStr, /*p_end*/ nullptr);
 

--- a/src/console_reporter.cc
+++ b/src/console_reporter.cc
@@ -56,7 +56,7 @@ bool ConsoleReporter::ReportContext(const Context& context) {
 BENCHMARK_EXPORT
 void ConsoleReporter::PrintHeader(const Run& run) {
   std::string str =
-      FormatString("%-*s %13s %15s %12s", static_cast<int>(name_field_width_),
+      FormatString("%-*s %13s %15s %15s", static_cast<int>(name_field_width_),
                    "Benchmark", "Time", "CPU", "Iterations");
   if (!run.counters.empty()) {
     if (output_options_ & OO_Tabular) {
@@ -171,7 +171,7 @@ void ConsoleReporter::PrintRunData(const Run& result) {
   }
 
   if (!result.report_big_o && !result.report_rms) {
-    printer(Out, COLOR_CYAN, "%10lld", result.iterations);
+    printer(Out, COLOR_CYAN, "%13lld", result.iterations);
   }
 
   for (auto& c : result.counters) {


### PR DESCRIPTION
Fixes #1663 by increasing the kMaxIterations limit.

An alternative could be to get rid of this limit; from the code, it is not clear why it is needed.